### PR TITLE
Adds partial pagination capabilities

### DIFF
--- a/src/app/common/components/dataset-table/dataset-table.component.html
+++ b/src/app/common/components/dataset-table/dataset-table.component.html
@@ -18,6 +18,8 @@
 
   <mat-paginator
     (page)="updatePagination($event)"
+    [pageIndex]="pageIndex"
+    [pageSize]="pageSize"
     [pageSizeOptions]="pageSizeOptions"
     aria-label="Select page of periodic elements"
     showFirstLastButtons

--- a/src/app/common/components/dataset-table/dataset-table.component.ts
+++ b/src/app/common/components/dataset-table/dataset-table.component.ts
@@ -31,6 +31,8 @@ export class DatasetTableComponent implements OnInit {
   protected pageSizeOptions: number[] = [1, 2, 3];
   protected pageSize: number = 3;
   protected pageIndex: number = 0;
+  protected sortColumn: String = "";
+  protected sortDirection: "asc" | "desc" | "" = "";
 
   constructor(private dataService: DataService) {}
 
@@ -44,7 +46,8 @@ export class DatasetTableComponent implements OnInit {
    * @param $event - The sorting event emitted by the Sort component.
    */
   updateSorting($event: Sort) {
-    // Todo: Not implemented
+    this.sortColumn = $event.active;
+    this.sortDirection = $event.direction;
     this.fetchTableData();
   }
 
@@ -78,6 +81,8 @@ export class DatasetTableComponent implements OnInit {
       this.tableName,
       this.pageIndex,
       this.pageSize,
+      this.sortColumn as string,
+      this.sortDirection
     );
   }
 }

--- a/src/app/common/components/dataset-table/dataset-table.component.ts
+++ b/src/app/common/components/dataset-table/dataset-table.component.ts
@@ -28,9 +28,9 @@ export class DatasetTableComponent implements OnInit {
   @Input() displayedColumns: string[] = [];
 
   protected data$!: Observable<Record<string, any>[]>;
-  protected pageSizeOptions: number[] = [5, 10, 15];
-  private pageCriteria: PageEvent | null = null;
-  private sortCriteria: Sort | null = null;
+  protected pageSizeOptions: number[] = [1, 2, 3];
+  protected pageSize: number = 3;
+  protected pageIndex: number = 0;
 
   constructor(private dataService: DataService) {}
 
@@ -44,7 +44,7 @@ export class DatasetTableComponent implements OnInit {
    * @param $event - The sorting event emitted by the Sort component.
    */
   updateSorting($event: Sort) {
-    this.sortCriteria = $event;
+    // Todo: Not implemented
     this.fetchTableData();
   }
 
@@ -53,7 +53,8 @@ export class DatasetTableComponent implements OnInit {
    * @param $event - The pagination event emitted Paginator component.
    */
   updatePagination($event: PageEvent) {
-    this.pageCriteria = $event;
+    this.pageSize = $event.pageSize;
+    this.pageIndex = $event.pageIndex;
     this.fetchTableData();
   }
 
@@ -73,7 +74,10 @@ export class DatasetTableComponent implements OnInit {
    * ordering criteria.
    */
   private fetchTableData(): void {
-    // Todo: include pagination and ordering params
-    this.data$ = this.dataService.getTableData(this.tableName);
+    this.data$ = this.dataService.getTableData(
+      this.tableName,
+      this.pageIndex,
+      this.pageSize,
+    );
   }
 }

--- a/src/app/common/components/dataset-table/dataset-table.component.ts
+++ b/src/app/common/components/dataset-table/dataset-table.component.ts
@@ -5,6 +5,7 @@ import { MatSortModule, Sort } from "@angular/material/sort";
 import { MatTableModule } from "@angular/material/table";
 import { Observable, of } from "rxjs";
 import { catchError } from "rxjs/operators";
+import { environment } from "~environments/environment";
 import { DataService } from "~services/data/data.service";
 
 /**
@@ -28,8 +29,8 @@ export class DatasetTableComponent implements OnInit {
   @Input() displayedColumns: string[] = [];
 
   protected data$!: Observable<Record<string, any>[]>;
-  protected pageSizeOptions: number[] = [1, 2, 3];
-  protected pageSize: number = 3;
+  protected pageSizeOptions: number[] = environment.pageSizeOptions;
+  protected pageSize: number = environment.pageSizeDefault;
   protected pageIndex: number = 0;
   protected sortColumn: String = "";
   protected sortDirection: "asc" | "desc" | "" = "";

--- a/src/app/common/services/data/data.service.ts
+++ b/src/app/common/services/data/data.service.ts
@@ -1,3 +1,4 @@
+import { HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { map, Observable, shareReplay } from "rxjs";
 
@@ -31,8 +32,17 @@ export class DataService {
    * @param tableName The name of the table to fetch data from.
    * @returns An observable containing table data.
    */
-  getTableData(tableName: string): Observable<any> {
-    return this.apiService.get<any>(`db/${tableName}`);
+  getTableData(tableName: string, pageIndex?: number, pageSize?: number): Observable<any> {
+
+    // Convert pagination parameters to HTTP parameters
+    const params = new HttpParams({
+      fromObject: {
+        _page_: pageIndex || 1,
+        _limit_: pageSize || 0,
+      }
+    });
+
+    return this.apiService.get<any>(`db/${tableName}`, {params: params});
   }
 
   /**

--- a/src/app/common/services/data/data.service.ts
+++ b/src/app/common/services/data/data.service.ts
@@ -30,17 +30,30 @@ export class DataService {
   /**
    * Returns data from a database table by name.
    * @param tableName The name of the table to fetch data from.
+   * @param pageIndex The index of the page to fetch (optional).
+   * @param pageSize The size of the page to fetch (optional).
+   * @param orderBy The column name to sort by (optional).
+   * @param direction The direction to sort by (optional).
    * @returns An observable containing table data.
    */
-  getTableData(tableName: string, pageIndex?: number, pageSize?: number): Observable<any> {
+  getTableData(
+    tableName: string, pageIndex?: number, pageSize?: number, orderBy?: string, direction?: string
+  ): Observable<any> {
 
-    // Convert pagination parameters to HTTP parameters
-    const params = new HttpParams({
+    let params = new HttpParams({
       fromObject: {
         _page_: pageIndex || 1,
         _limit_: pageSize || 0,
       }
     });
+
+    if (orderBy) {
+      params = params.set("_order_by_", orderBy);
+    }
+
+    if (direction) {
+      params = params.set("_direction_", direction);
+    }
 
     return this.apiService.get<any>(`db/${tableName}`, {params: params});
   }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,6 @@
 export const environment = {
   apiUrl: "http://localhost:8081",
   projectSourceUrl: "https://www.github.com/mwvgroup/Pitt-Google-Broker",
+  pageSizeOptions: [1, 2, 3],
+  pageSizeDefault: 3
 };


### PR DESCRIPTION
Adds the ability to:

- Configure default pagination settings from the build environment
- Change the displayed page size in the UI
- Change the sort column and direction from the UI

This PR does not add support for changing the displayed page number/index. That requires fetching additional data from the API which won't be available until next week's release.